### PR TITLE
Broken example

### DIFF
--- a/Documentation/Provisioning-Deployment.org
+++ b/Documentation/Provisioning-Deployment.org
@@ -346,7 +346,6 @@ RUN npm install -g nodemon
 EXPOSE 3000
 WORKDIR /app
 COPY . .
-RUN npm install
 ENV DEBUG='qfapp:*'
 ENTRYPOINT ["npm", "run", "dev"]
 #+end_src


### PR DESCRIPTION
Running `npm install` assumes that there is the file `package.json` in the working directory. Since this is not the case, the image build fails. This fixes the error. Alternatively, run `npm init -y` before `npm install`, but this is cleaner.

Or was the intention to let the students find out the solution? Quite frustrating though if you never have experienced docker and its error messages...