### PR TITLE
Revert "Broken example"

### DIFF
--- a/Documentation/Provisioning-Deployment.org
+++ b/Documentation/Provisioning-Deployment.org
@@ -346,6 +346,7 @@ RUN npm install -g nodemon
 EXPOSE 3000
 WORKDIR /app
 COPY . .
+RUN npm install
 ENV DEBUG='qfapp:*'
 ENTRYPOINT ["npm", "run", "dev"]
 #+end_src


### PR DESCRIPTION
Reverts mickesv/ProvisioningDeployment#2

Actually, when I think about it, keeping the "npm install" in there means that the Dockerfile is a complete example for running a node.js app.